### PR TITLE
Bug fix - wasn't putting last sequence in JSON

### DIFF
--- a/faa-summarize.py
+++ b/faa-summarize.py
@@ -25,6 +25,9 @@ for fname in sys.argv[1:]:
                 # Part of the sequence, increment the length
                 if gene is not None:
                     gene['length'] += len(l.rstrip('*\n'))
+        if gene is not None:
+            strain.append(gene)
+
     result[fname] = strain
 
 print json.dumps({'gene_order':result})


### PR DESCRIPTION
Interestingly this missing gene had all sorts of effects on the column ordering when ordering to the reference - weird gaps etc.

Maybe we should use biopython?
